### PR TITLE
Feature/python binding threads

### DIFF
--- a/TTD/TTD.hpp
+++ b/TTD/TTD.hpp
@@ -104,10 +104,12 @@ namespace TTD {
 
 	typedef struct TTD_Replay_ActiveThreadInfo {
 		TTD_Replay_ThreadInfo* info;
-		uint64_t unk1;
-		uint64_t unk2;
-		uint64_t unk3;
-		uint64_t unk4;
+		// next Major:Minor position where this thread is active
+		uint64_t nextMajor;
+		uint64_t nextMinor;
+		// last Major:Minor position where this thread was active
+		uint64_t lastMajor;
+		uint64_t lastMinor;
 	}TTD_Replay_ActiveThreadInfo;
 	/*
 	*(_QWORD *)this = &TTD::Replay::Cursor::`vftable'{for `TTD::Replay::ICursor'};

--- a/example_api/example_api.py
+++ b/example_api/example_api.py
@@ -31,6 +31,25 @@ print(f"Modules ({eng.get_module_count()}):")
 for mod in sorted(eng.get_module_list(), key=lambda x: x.base_addr):
     print(f"\t0x{mod.base_addr:x} - 0x{mod.base_addr + mod.image_size:x}\t{mod.path}")
 
+# Print Thread active zones
+print(f"Threads ({cursor.get_thread_count()}):")
+## Save the current position
+position_save = cursor.get_position()
+## Get Threads' starting position
+threads = {} # Thread ID => {"begin": position, "end": position}
+cursor.set_position(first)
+for thread in cursor.get_thread_list():
+    threads.setdefault(thread.threadid, {})["begin"] = f"{thread.next_major:x}:{thread.next_minor:x}"
+## Get Threads' ending position
+cursor.set_position(last)
+for thread in cursor.get_thread_list():
+    threads.setdefault(thread.threadid, {})["end"] = f"{thread.last_major:x}:{thread.last_minor:x}"
+## Restore saved position
+cursor.set_position(position_save)
+## Print out the resulting ranges
+for threadid, info in threads.items():
+    print(f"\t[0x{threadid:x}] {info['begin']} -> {info['end']}")
+
 # Read the memory
 print("@128[RCX]: %s" % cursor.read_mem(ctxt.rcx, 16))
 print("@128[RCX+4]: %s" % cursor.read_mem(ctxt.rcx + 4, 16))

--- a/python-bindings/module.cpp
+++ b/python-bindings/module.cpp
@@ -28,7 +28,11 @@ PYBIND11_MODULE(pyTTD, m) {
         .def_readonly("path", &TTD::TTD_Replay_Module::path);
 
     py::class_<TTD::TTD_Replay_ThreadInfo, std::unique_ptr<TTD::TTD_Replay_ThreadInfo, py::nodelete>>(m, "ThreadInfo")
-        .def_readonly("threadid", &TTD::TTD_Replay_ThreadInfo::threadid);
+        .def_readonly("threadid", &TTD::TTD_Replay_ThreadInfo::threadid); 
+    py::class_<TTD::TTD_Replay_ActiveThreadInfo, std::unique_ptr<TTD::TTD_Replay_ActiveThreadInfo, py::nodelete>>(m, "ActiveThreadInfo")
+        .def_property("threadid", [](TTD::TTD_Replay_ActiveThreadInfo& self) {
+            return self.info->threadid;
+        }, nullptr)
 
     py::class_<TTD::TTD_Replay_RegisterContext, std::unique_ptr<TTD::TTD_Replay_RegisterContext, py::nodelete>>(m, "RegisterContext")
         .def_readonly("cs", &TTD::TTD_Replay_RegisterContext::cs)
@@ -72,10 +76,13 @@ PYBIND11_MODULE(pyTTD, m) {
     py::class_<TTD::Cursor>(m, "Cursor")
         .def("set_position", py::overload_cast<TTD::Position*>(&TTD::Cursor::SetPosition), py::arg("position"))
         .def("set_position", py::overload_cast<unsigned __int64, unsigned __int64>(&TTD::Cursor::SetPosition), py::arg("Major"), py::arg("Minor"))
+        .def("get_position", py::overload_cast<>(&TTD::Cursor::GetPosition))
+        .def("get_position", py::overload_cast<uint32_t>(&TTD::Cursor::GetPosition), py::arg("threadid"))
         .def("get_thread_count", &TTD::Cursor::GetThreadCount)
         .def("get_program_counter", py::overload_cast<>(&TTD::Cursor::GetProgramCounter))
         .def("get_thread_info", py::overload_cast<>(&TTD::Cursor::GetThreadInfo))
-        .def("get_crossplatform_context", &TTD::Cursor::GetCrossPlatformContext)
+        .def("get_crossplatform_context", py::overload_cast<>(&TTD::Cursor::GetCrossPlatformContext))
+        .def("get_crossplatform_context", py::overload_cast<uint32_t>(&TTD::Cursor::GetCrossPlatformContext), py::arg("threadid"))
         .def("read_mem", [](TTD::Cursor &self, TTD::GuestAddress addr, unsigned __int64 size) {
             TTD::MemoryBuffer *membuf = self.QueryMemoryBuffer(addr, size);
             std::string x((char*) membuf->data, membuf->size);
@@ -94,8 +101,25 @@ PYBIND11_MODULE(pyTTD, m) {
             return replayrez.stepCount;
         })
         .def("add_memory_watchpoint", &TTD::Cursor::AddMemoryWatchpoint)
-        .def("remove_memory_watchpoint", &TTD::Cursor::RemoveMemoryWatchpoint);
-
+        .def("remove_memory_watchpoint", &TTD::Cursor::RemoveMemoryWatchpoint)
+        .def("get_module_count", &TTD::Cursor::GetModuleCount)
+        .def("get_module_list", [](TTD::Cursor& self) {
+            std::vector<TTD::TTD_Replay_Module> mods;
+            TTD::TTD_Replay_ModuleInstance* mod_list = self.GetModuleList();
+            for (int i = 0; i < self.GetModuleCount(); i++) {
+                mods.push_back(*mod_list[i].module);
+            }
+            return mods;
+        })
+        .def("get_thread_list", [](TTD::Cursor& self) {
+            std::vector<TTD::TTD_Replay_ActiveThreadInfo> threads;
+            TTD::TTD_Replay_ActiveThreadInfo* thread_list = self.GetThreadList();
+            for (int i = 0; i < self.GetThreadCount(); i++) {
+                threads.push_back(thread_list[i]);
+            }
+            return threads;
+        });
+        
     py::class_<TTD::ReplayEngine>(m, "ReplayEngine")
         .def(py::init<>())
         .def("initialize", &TTD::ReplayEngine::Initialize, py::arg("trace_filename"))

--- a/python-bindings/module.cpp
+++ b/python-bindings/module.cpp
@@ -33,6 +33,10 @@ PYBIND11_MODULE(pyTTD, m) {
         .def_property("threadid", [](TTD::TTD_Replay_ActiveThreadInfo& self) {
             return self.info->threadid;
         }, nullptr)
+        .def_readonly("next_major", &TTD::TTD_Replay_ActiveThreadInfo::nextMajor)
+        .def_readonly("next_minor", &TTD::TTD_Replay_ActiveThreadInfo::nextMinor)
+        .def_readonly("last_major", &TTD::TTD_Replay_ActiveThreadInfo::lastMajor)
+        .def_readonly("last_minor", &TTD::TTD_Replay_ActiveThreadInfo::lastMinor);
 
     py::class_<TTD::TTD_Replay_RegisterContext, std::unique_ptr<TTD::TTD_Replay_RegisterContext, py::nodelete>>(m, "RegisterContext")
         .def_readonly("cs", &TTD::TTD_Replay_RegisterContext::cs)


### PR DESCRIPTION
* Add Python wrappers for function introduced in #1 
* Document fields from `ActiveThreadInfo` structures
  * Next position of thread activity
  * Last position of thread activity

These values are highlighted it in the Python example_api:

```python
# [Thread ID] first position -> last position
Threads (9):
        [0x13b4] 29:0 -> 15673:0
        [0x1d0] f3:0 -> 3c3:0
        [0x1120] b1d:0 -> 956f:0
        [0x150] c33:0 -> 9c86:0
        [0x1c1c] d4a:0 -> 15806:0
        [0x19d4] df6:0 -> a0d8:0
        [0x1d34] 433a:0 -> 35d24:0
        [0x1630] 5930:0 -> 23375:0
        [0x1af4] 22ef5:0 -> 22f88:0
```