### PR TITLE
fix BP_FLAGS::READ value and add some functions

### DIFF
--- a/TTD/TTD.cpp
+++ b/TTD/TTD.cpp
@@ -47,19 +47,26 @@ namespace TTD {
 		return this->GetCrossPlatformContext(0);
 	}
 
+	//The caller should free ctxt after call GetCrossPlatformContext function
 	void* Cursor::GetCrossPlatformContext(uint32_t threadId) {
 		void* ctxt = malloc(0xA70);
+		if (NULL == ctxt)
+			return NULL;
 		return this->cursor->ICursor->GetCrossPlatformContext(cursor, ctxt, threadId);
 	}
 
+	//The caller should free memorybuffer and memorybuffer->data (same value as buf->dst_buffer) after call QueryMemoryBuffer function
 	struct MemoryBuffer* Cursor::QueryMemoryBuffer(GuestAddress address, unsigned __int64 size) {
 		struct MemoryBuffer* memorybuffer = (struct MemoryBuffer*)malloc(sizeof(struct MemoryBuffer));
 		struct TBuffer* buf = (struct TBuffer*)malloc(sizeof(struct TBuffer));
-		if (buf == NULL)
+		if (NULL == buf || NULL == memorybuffer)
 			return NULL;
 		buf->size = size;
 		buf->dst_buffer = (void*)malloc(size);
+		if (NULL == buf->dst_buffer)
+			return NULL;
 		this->cursor->ICursor->QueryMemoryBuffer(cursor, memorybuffer, address, buf, 0);
+		free(buf);
 		return memorybuffer;
 	}
 
@@ -85,6 +92,14 @@ namespace TTD {
 
 	Position* Cursor::GetPosition() {
 		return this->GetPosition(0);
+	}
+
+	Position* Cursor::GetPreviousPosition(unsigned int ThreadId) {
+		return this->cursor->ICursor->GetPreviousPosition(cursor, ThreadId);
+	}
+
+	Position* Cursor::GetPreviousPosition() {
+		return this->GetPreviousPosition(0);
 	}
 
 	bool Cursor::AddMemoryWatchpoint(TTD_Replay_MemoryWatchpointData* data) {

--- a/TTD/TTD.hpp
+++ b/TTD/TTD.hpp
@@ -83,6 +83,9 @@ namespace TTD {
 		struct TTD_Replay_IThreadView_vftable* IThreadView;
 	} TTD_Replay_IThreadView;
 
+	#define MEM_READ_EVENT_FLAG 0
+	#define MEM_WRITE_EVENT_FLAG 1
+
 	typedef struct TTD_Replay_MemoryWatchpointData {
 		GuestAddress addr;
 		unsigned __int64 size;
@@ -91,8 +94,8 @@ namespace TTD {
 
 
 	const enum BP_FLAGS {
+		READ = 1,
 		WRITE = 2,
-		READ = 3,
 		EXEC = 4
 	};
 	typedef struct TTD_Replay_MemoryWatchpointResult {
@@ -136,7 +139,7 @@ namespace TTD {
 		void* unk10;
 		struct Position* (__fastcall* GetPosition)(TTD_Replay_ICursor* self, unsigned int ThreadId);
 		//  const struct Position *(__stdcall __high *_GetPreviousPosition_Cursor_Replay_TTD__UEBAAEBUPosition_23_W4ThreadId_3__Z)(enum TTD::ThreadId);
-		void* unk12;
+		struct Position* (__fastcall* GetPreviousPosition)(TTD_Replay_ICursor* self, unsigned int ThreadId);
 		GuestAddress(__stdcall* GetProgramCounter)(TTD_Replay_ICursor* self, unsigned int ThreadId);
 		//  enum Nirvana::GuestAddress (__stdcall __high *_GetStackPointer_Cursor_Replay_TTD__UEBA_AW4GuestAddress_Nirvana__W4ThreadId_3__Z)(enum TTD::ThreadId);
 		void* unk14;
@@ -377,7 +380,7 @@ namespace TTD {
 
 	typedef struct TTD_Replay_IThreadView_vftable {
 		// TTD::Replay::ExecutionState::GetThreadInfo(void)
-		void* unk1;
+		struct TTD_Replay_ThreadInfo*(*GetThreadInfo)(TTD_Replay_IThreadView* self);
 		// offset TTD::Replay::ExecutionState::GetTebAddress(void)
 		void* unk2;
 		Position* (*GetPosition)(TTD_Replay_IThreadView* self);
@@ -396,7 +399,7 @@ namespace TTD {
 		// TTD::Replay::ExecutionState::QueryMemoryRange(Nirvana::GuestAddress)
 		void* unk11;
 		// TTD::Replay::ExecutionState::QueryMemoryBuffer(Nirvana::GuestAddress, TTD::TBufferView<0>)
-		void* unk12;
+		struct MemoryBuffer* (*QueryMemoryBuffer)(TTD_Replay_IThreadView* self, struct MemoryBuffer*, GuestAddress, struct TBuffer* buf);
 		// TTD::Replay::ExecutionState::QueryMemoryBufferWithRanges(Nirvana::GuestAddress, TTD::TBufferView<0>, unsigned __int64, TTD::Replay::MemoryRange*)
 		void* unk13;
 		// Destructor
@@ -427,6 +430,8 @@ namespace TTD {
 		void SetPosition(unsigned __int64 Major, unsigned __int64 Minor);
 		struct Position* GetPosition();
 		struct Position* GetPosition(unsigned int ThreadId);
+		struct Position* GetPreviousPosition();
+		struct Position* GetPreviousPosition(unsigned int ThreadId);
 		unsigned __int64 GetThreadCount();
 		GuestAddress GetProgramCounter();
 		GuestAddress GetProgramCounter(unsigned int ThreadId);

--- a/TTD/TTD.hpp
+++ b/TTD/TTD.hpp
@@ -98,6 +98,10 @@ namespace TTD {
 		WRITE = 2,
 		EXEC = 4
 	};
+	/*
+	 * This structure is used by the @mem argument of the memory callback
+	 * @flags: MEM_READ_EVENT_FLAG or MEM_WRITE_EVENT_FLAG, if the memory event is resp. a "read" or a "write" event
+	 */
 	typedef struct TTD_Replay_MemoryWatchpointResult {
 		GuestAddress addr;
 		unsigned __int64 size;


### PR DESCRIPTION
Hi @commial,

This PR fix BP_FLAGS::READ value in issue #20 and add some functions which have been tested.

When I call some APIs in batches without free the heap pointers from them, the quick memory leak happens...
So, I also add some comments to remind callers to do the extra free job. 

Thank again for sharing the cool project.

Best wishes,
YHZX_2013
