### PR TITLE
Allow passing DLL paths

### DIFF
--- a/TTD/TTD.cpp
+++ b/TTD/TTD.cpp
@@ -119,7 +119,7 @@ namespace TTD {
 		return this->cursor->ICursor->GetModuleList(cursor);
 	}
 
-	ReplayEngine::ReplayEngine() {
+	ReplayEngine::ReplayEngine(const wchar_t* ttdReplayPath, const wchar_t* ttdReplayCpuPath) {
 		HINSTANCE hinstLib;
 		PROC_Initiate InitiateReplayEngineHandshake;
 		PROC_Create CreateReplayEngineWithHandshake;
@@ -128,7 +128,12 @@ namespace TTD {
 		SHA256_CTX ctx;
 		BYTE sha[32];
 
-		hinstLib = LoadLibrary(TEXT("TTDReplay.dll"));
+		hinstLib = LoadLibraryW(ttdReplayCpuPath);
+		if (hinstLib == NULL) {
+			throw std::exception("Unable to find TTDReplayCPU.dll");
+		}
+
+		hinstLib = LoadLibraryW(ttdReplayPath);
 		if (hinstLib == NULL) {
 			throw std::exception("Unable to find TTDReplay.dll");
 		}

--- a/TTD/TTD.hpp
+++ b/TTD/TTD.hpp
@@ -513,7 +513,7 @@ namespace TTD {
 		TTD_Replay_ReplayEngine* engine;
 
 	public:
-		ReplayEngine();
+		ReplayEngine(const wchar_t* ttdReplayPath=L"TTDReplay.dll", const wchar_t* ttdReplayCpuPath=L"TTDReplayCPU.dll");
 
 		/**** Wrapping around the vftable ****/
 		bool Initialize(const wchar_t* trace_filename);


### PR DESCRIPTION
From a fork: https://github.com/airbus-cert/ttd-bindings/pull/2